### PR TITLE
Experiments - devise glue

### DIFF
--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -100,6 +100,8 @@ module ActiveModel
             cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
             self.send("#{attribute}_digest_legacy=", BCrypt::Password.create(unencrypted_password, cost: cost))
           end
+
+          super
         end
 
         define_method("#{attribute}_confirmation=") do |unencrypted_password|

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -79,7 +79,7 @@ module ActiveModel
           # when there is an error, the message is added to the password attribute instead
           # so that the error message will make sense to the end-user.
           validate do |record|
-            record.errors.add(attribute, :blank) unless record.send("#{attribute}_digest").present?
+            record.errors.add(attribute, :blank) unless record.send("#{attribute}_digest_legacy").present?
           end
 
           validates_length_of attribute, maximum: ActiveModel::SecurePassword::MAX_PASSWORD_LENGTH_ALLOWED
@@ -94,11 +94,11 @@ module ActiveModel
 
         define_method("#{attribute}=") do |unencrypted_password|
           if unencrypted_password.nil?
-            self.send("#{attribute}_digest=", nil)
+            self.send("#{attribute}_digest_legacy=", nil)
           elsif !unencrypted_password.empty?
             instance_variable_set("@#{attribute}", unencrypted_password)
             cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST : BCrypt::Engine.cost
-            self.send("#{attribute}_digest=", BCrypt::Password.create(unencrypted_password, cost: cost))
+            self.send("#{attribute}_digest_legacy=", BCrypt::Password.create(unencrypted_password, cost: cost))
           end
         end
 
@@ -117,7 +117,7 @@ module ActiveModel
         #   user.authenticate_password('notright')      # => false
         #   user.authenticate_password('mUc3m00RsqyRe') # => user
         define_method("authenticate_#{attribute}") do |unencrypted_password|
-          attribute_digest = send("#{attribute}_digest")
+          attribute_digest = send("#{attribute}_digest_legacy")
           BCrypt::Password.new(attribute_digest).is_password?(unencrypted_password) && self
         end
 

--- a/activemodel/lib/active_model/secure_password.rb
+++ b/activemodel/lib/active_model/secure_password.rb
@@ -101,7 +101,7 @@ module ActiveModel
             self.send("#{attribute}_digest_legacy=", BCrypt::Password.create(unencrypted_password, cost: cost))
           end
 
-          super
+          super(unencrypted_password)
         end
 
         define_method("#{attribute}_confirmation=") do |unencrypted_password|


### PR DESCRIPTION
In order to get devise and `has_secure_password` from rails to co-exist, I had to change `password_digest` to `password_digest_legacy`. Using the "correct" way and passing an argument to `has_secure_password` required that I update all the call sites in user space, which I worried would be fraught with error.

So, I changed it under the hood to use a different database column and then re-named it in our application. The last bit was to pass the unencrypted password to super so devise could access it as well.